### PR TITLE
Add account unlocking instructions, improve docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Select the database:
 `\connect lecture_manager`
 
 And unlock your account:
-`UPDATE "AspNetUsers" SET "LockoutEnabled" = false WHERE "UserName" = "testuser";`
+`UPDATE "AspNetUsers" SET "LockoutEnabled" = false WHERE "UserName" = 'testuser';`
 
 Now you should be able to login.
 

--- a/README.md
+++ b/README.md
@@ -45,4 +45,17 @@ http://localhost:8080/api/user/register
 ```
 The generated user is locked out by default, so it must be activated manually via the corresponding database entry.
 
+First, connect to yout postgres installation:
+`psql -U postgres -W`
+If you are using docker, the easiest way to get there is opening a shell within the container:
+`docker exec -ti lecturedatabase /bin/bash`
+
+Select the database:
+`\connect lecture_manager`
+
+And unlock your account:
+`UPDATE "AspNetUsers" SET "LockoutEnabled" = false WHERE "UserName" = "testuser";`
+
+Now you should be able to login.
+
 Finally, you can also adjust the folders used in the docker container by adjusting the docker-compose file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '3.7'
 services:
     lecture-database:
         image: postgres:13-alpine
@@ -13,10 +13,7 @@ services:
             - 5432:5432
         
     lecture-manager:
-        image: lecturemanager
-        build:
-            context: .
-            dockerfile: ./Dockerfile
+        image: ghcr.io/telecooperation/lecture-recording-manager:latest
         container_name: lecturemanager
         depends_on:
             - lecture-database


### PR DESCRIPTION
Some minor changes:
- Add instructions on how to unlock a new account
- Ensure compatibility with the apt-packaged docker compose from ubuntu 21.04 repo (I did not see any 3.8 or 3.9 exclusive features used)
- Use the prebuilt image from GitHub (local building is broken for me)